### PR TITLE
Prevent the need to call concat in map.

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -30,10 +30,10 @@ Writer.prototype.tell = function(y) {
 };
 
 Writer.prototype.map = function(f) {
-  return this.chain(function(a) {
-    return Writer(function() {
-      return Tuple2(f(a), { concat: identity });
-    });
+  var self = this;
+  return Writer(function() {
+    var result = self.run();
+    return Tuple2(f(result._1), result._2);
   });
 };
 


### PR DESCRIPTION
The reason for the change is so it's easier to change the semigroup when
constructing the writer. The way the default `of` works assumes that
concat will work with every semigroup, this is a fallacy and is proven
to not work with every semigroup.